### PR TITLE
Switch to ragnar::retrieve for doc search

### DIFF
--- a/R/chat.r
+++ b/R/chat.r
@@ -19,7 +19,7 @@
 #'
 #' @return Invisibly returns the `client` object for further use or inspection.
 #'
-#' @seealso [ellmer::chat_openai], [ragnar::ragnar_retrieve]
+#' @seealso [ellmer::chat_openai], [ragnar::retrieve]
 #' @importFrom rlang .data
 #' @export
 #' @examples
@@ -250,15 +250,17 @@ quartohelp_setup_client <- function(client, store) {
 quartohelp_retrieve_tool <- function(store) {
   retrieved_ids <- integer()
   rag_retrieve_quarto_excerpts <- function(text) {
-    # Retrieve relevant chunks using hybrid (vector/BM25) search,
-    # excluding previously returned IDs in this session.
-    chunks <- ragnar::ragnar_retrieve(
+    # Retrieve relevant chunks using hybrid (vector/BM25) search via
+    # `ragnar::retrieve()`, excluding previously returned IDs in this
+    # session.
+    chunks <- ragnar::retrieve(
       store,
       text,
       top_k = 10,
       filter = !.data$id %in% retrieved_ids
     )
 
+    # Track retrieved IDs to avoid returning duplicates on subsequent calls
     retrieved_ids <<- unique(unlist(c(retrieved_ids, chunks$id)))
     chunks
   }

--- a/man/ask.Rd
+++ b/man/ask.Rd
@@ -41,5 +41,5 @@ if (interactive() && nzchar(Sys.getenv("OPENAI_API_KEY"))) {
 }
 }
 \seealso{
-\link[ellmer:chat_openai]{ellmer::chat_openai}, \link[ragnar:ragnar_retrieve]{ragnar::ragnar_retrieve}
+\link[ellmer:chat_openai]{ellmer::chat_openai}, \link[ragnar:retrieve]{ragnar::retrieve}
 }


### PR DESCRIPTION
## Summary
- replace deprecated `ragnar::ragnar_retrieve()` with `ragnar::retrieve()`
- update comments and docs to reflect new retrieval function
- track retrieved ids to continue duplicate filtering

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1706feeb4832cbd14042456b42c15