### PR TITLE
Update store build script for new Ragnar API

### DIFF
--- a/scripts/make-store.R
+++ b/scripts/make-store.R
@@ -42,7 +42,7 @@ stopifnot(file.exists(sitemap$path))
 
 store_location <- "quarto.ragnar.store"
 
-store <- ragnar_store_create(
+store <- store_create(
   store_location,
   name = "quarto_docs",
   embed = \(x) ragnar::embed_openai(x, model = "text-embedding-3-small"),
@@ -58,10 +58,10 @@ for (r in seq_len(nrow(sitemap))) {
   doc@origin <- url
   chunks <- markdown_chunk(doc)
 
-  ragnar_store_insert(store, chunks)
+  store_insert(store, chunks)
 }
 
-ragnar_store_build_index(store)
+store_build_index(store)
 
 DBI::dbDisconnect(store@con)
 


### PR DESCRIPTION
## Summary
- Use `store_create`, `store_insert`, and `store_build_index` to align with updated Ragnar API in `scripts/make-store.R`
- Preserve embedding routine using `ragnar::embed_openai`

## Testing
- `Rscript scripts/make-store.R` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68a1719bfd60832cadf4b2ac2ea05c86