### PR TITLE
Update ragnar dependency to >=0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,15 +17,14 @@ Imports:
     dplyr,
     ellmer (>= 0.2.1.9000),
     promises,
-    ragnar (>= 0.2.0),
+    ragnar (>= 0.3.0),
     rlang,
     shiny,
     shinychat (>= 0.2.0.9000),
     stringi
 Remotes:
     posit-dev/shinychat/pkg-r,
-    tidyverse/ellmer,
-    tidyverse/ragnar
+    tidyverse/ellmer
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
## Summary
- require ragnar >= 0.3.0 in DESCRIPTION
- remove remote reference to ragnar

## Testing
- ⚠️ `R -q -e 'devtools::document()'` (command not found)
- ⚠️ `R CMD check .` (command not found)
- ⚠️ `apt-get update` (403 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a1719e0240832c8f4af0869f179358